### PR TITLE
update to latest rsocket-rpc-java and reactor versions

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group=io.netifi.proteus
-version=0.9.4
+version=0.9.5

--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -35,7 +35,7 @@ task ciVersion {
 build.dependsOn ciVersion
 
 ext {
-    rsocketRpcVersion = '0.2.2'
+    rsocketRpcVersion = '0.2.3'
     protobufVersion = '3.6.1'
 }
 
@@ -88,14 +88,14 @@ dependencies {
     testCompile 'junit:junit:4.12'
 
     testCompile 'javax.inject:javax.inject:1'
-    testCompile 'io.projectreactor:reactor-test:3.1.9.RELEASE'
+    testCompile 'io.projectreactor:reactor-test:3.2.0.RELEASE'
     testCompile "com.google.protobuf:protobuf-java:$protobufVersion"
     testCompile 'org.hdrhistogram:HdrHistogram:2.1.10'
     testCompile 'org.apache.logging.log4j:log4j-api:2.9.0'
     testCompile 'org.apache.logging.log4j:log4j-core:2.9.0'
     testCompile 'org.apache.logging.log4j:log4j-slf4j-impl:2.9.0'
-    testCompile 'io.rsocket:rsocket-transport-netty:0.11.7'
-    testCompile 'io.rsocket:rsocket-transport-local:0.11.7'
+    testCompile 'io.rsocket:rsocket-transport-netty:0.11.8'
+    testCompile 'io.rsocket:rsocket-transport-local:0.11.8'
     testCompile 'org.mockito:mockito-all:1.10.19'
 }
 

--- a/proteus-client/src/main/java/io/netifi/proteus/Proteus.java
+++ b/proteus-client/src/main/java/io/netifi/proteus/Proteus.java
@@ -26,7 +26,7 @@ import org.slf4j.LoggerFactory;
 import reactor.core.Exceptions;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.MonoProcessor;
-import reactor.ipc.netty.tcp.TcpClient;
+import reactor.netty.tcp.TcpClient;
 
 /** This is where the magic happens */
 public class Proteus implements Closeable {
@@ -256,7 +256,7 @@ public class Proteus implements Closeable {
         if (sslDisabled) {
           clientTransportFactory =
               address -> {
-                TcpClient client = TcpClient.create(opts -> opts.connectAddress(() -> address));
+                TcpClient client = TcpClient.create().addressSupplier(() -> address);
                 return TcpClientTransport.create(client);
               };
         } else {
@@ -277,8 +277,7 @@ public class Proteus implements Closeable {
             clientTransportFactory =
                 address -> {
                   TcpClient client =
-                      TcpClient.create(
-                          opts -> opts.connectAddress(() -> address).sslContext(sslContext));
+                      TcpClient.create().addressSupplier(() -> address).secure(sslContext);
                   return TcpClientTransport.create(client);
                 };
           } catch (Exception sslException) {

--- a/proteus-metrics-prometheus/src/main/java/io/netifi/proteus/prometheus/ProteusPrometheusBridge.java
+++ b/proteus-metrics-prometheus/src/main/java/io/netifi/proteus/prometheus/ProteusPrometheusBridge.java
@@ -26,9 +26,9 @@ import reactor.core.Disposable;
 import reactor.core.publisher.DirectProcessor;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import reactor.ipc.netty.http.server.HttpServer;
-import reactor.ipc.netty.http.server.HttpServerRequest;
-import reactor.ipc.netty.http.server.HttpServerResponse;
+import reactor.netty.http.server.HttpServer;
+import reactor.netty.http.server.HttpServerRequest;
+import reactor.netty.http.server.HttpServerResponse;
 
 @Named("ProteusPrometheusBridge")
 public class ProteusPrometheusBridge implements MetricsSnapshotHandler {
@@ -99,8 +99,11 @@ public class ProteusPrometheusBridge implements MetricsSnapshotHandler {
   }
 
   private void init() {
-    HttpServer.create(bindAddress, bindPort)
-        .newRouter(routes -> routes.post(metricsUrl, this::handle).get(metricsUrl, this::handle))
+    HttpServer.create()
+        .host(bindAddress)
+        .port(bindPort)
+        .route(routes -> routes.post(metricsUrl, this::handle).get(metricsUrl, this::handle))
+        .bind()
         .subscribe();
   }
 

--- a/proteus-tracing-openzipkin/build.gradle
+++ b/proteus-tracing-openzipkin/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     protobuf project (':proteus-tracing-idl')
     compile project (':proteus-client')
 
-    compile 'io.projectreactor.addons:reactor-adapter:3.1.7.RELEASE'
+    compile 'io.projectreactor.addons:reactor-adapter:3.2.0.RELEASE'
     compile "com.google.protobuf:protobuf-java-util:$protobufVersion"
 
     compile 'io.opentracing:opentracing-api:0.31.0'

--- a/proteus-tracing-openzipkin/src/test/java/io/netifi/proteus/tracing/ZipkinTracesStreamerTest.java
+++ b/proteus-tracing-openzipkin/src/test/java/io/netifi/proteus/tracing/ZipkinTracesStreamerTest.java
@@ -14,8 +14,8 @@ import org.junit.Ignore;
 import org.junit.Test;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import reactor.ipc.netty.http.client.HttpClient;
-import reactor.ipc.netty.resources.PoolResources;
+import reactor.netty.http.client.HttpClient;
+import reactor.netty.resources.ConnectionProvider;
 
 public class ZipkinTracesStreamerTest {
 
@@ -70,16 +70,14 @@ public class ZipkinTracesStreamerTest {
 
   private Mono<HttpClient> client() {
     return Mono.just(
-        HttpClient.builder()
-            .options(
-                builder ->
-                    builder
-                        .compression(true)
-                        .poolResources(PoolResources.fixed("proteusZipkinBridge"))
+        HttpClient.create(ConnectionProvider.fixed("proteusZipkinBridge"))
+            .compress(true)
+            .port(9411)
+            .tcpConfiguration(
+                tcpClient ->
+                    tcpClient
                         .option(ChannelOption.SO_KEEPALIVE, true)
                         .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 30_000)
-                        .host("127.0.0.1")
-                        .port(9411))
-            .build());
+                        .host("127.0.0.1")));
   }
 }


### PR DESCRIPTION
This PR includes migration to newer version of rsocket Java which includes upgrade to Reactor 3.2.0, and refactoring of SwitchTransformer which was renamed to SwitchTransformFlux and now supports Backpressure with prefetch size in online element because of the operator behavior  