### PR TITLE
remove uncessary address; plumb addressSelector through DefaultProteusBrokerService

### DIFF
--- a/proteus-client/src/main/java/io/netifi/proteus/DefaultProteusBrokerService.java
+++ b/proteus-client/src/main/java/io/netifi/proteus/DefaultProteusBrokerService.java
@@ -272,6 +272,7 @@ public class DefaultProteusBrokerService implements ProteusBrokerService, Dispos
 
               switch (u.getScheme()) {
                 case "ws":
+                case "wss":
                   b =
                       Broker.newBuilder()
                           .setWebSocketAddress(u.getHost())

--- a/proteus-client/src/main/java/io/netifi/proteus/DefaultProteusBrokerService.java
+++ b/proteus-client/src/main/java/io/netifi/proteus/DefaultProteusBrokerService.java
@@ -271,7 +271,6 @@ public class DefaultProteusBrokerService implements ProteusBrokerService, Dispos
   private synchronized void handleBrokerEvent(Event event) {
     logger.info("received broker event {} - {}", event.getType(), event.toString());
     Broker broker = event.getBroker();
-    InetSocketAddress address = this.addressSelector.apply(broker);
     switch (event.getType()) {
       case JOIN:
         handleJoinEvent(broker);

--- a/proteus-client/src/main/java/io/netifi/proteus/Proteus.java
+++ b/proteus-client/src/main/java/io/netifi/proteus/Proteus.java
@@ -95,6 +95,7 @@ public class Proteus implements Closeable {
             requestHandlingRSocket,
             inetAddress,
             group,
+            addressSelector,
             clientTransportFactory,
             poolSize,
             keepalive,

--- a/proteus-client/src/main/java/io/netifi/proteus/rsocket/transport/WeightedClientTransportSupplier.java
+++ b/proteus-client/src/main/java/io/netifi/proteus/rsocket/transport/WeightedClientTransportSupplier.java
@@ -19,6 +19,7 @@ import io.netifi.proteus.broker.info.Broker;
 import io.netifi.proteus.common.stats.Ewma;
 import io.rsocket.Closeable;
 import io.rsocket.transport.ClientTransport;
+import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -42,18 +43,18 @@ public class WeightedClientTransportSupplier implements Supplier<ClientTransport
   private final Broker broker;
 
   public WeightedClientTransportSupplier(
-      SocketAddress socketAddress,
+      Function<Broker, InetSocketAddress> addressSelector,
       Function<SocketAddress, ClientTransport> clientTransportFunction) {
-    this(Broker.getDefaultInstance(), socketAddress, clientTransportFunction);
+    this(Broker.getDefaultInstance(), addressSelector, clientTransportFunction);
   }
 
   public WeightedClientTransportSupplier(
       Broker broker,
-      SocketAddress socketAddress,
+      Function<Broker, InetSocketAddress> addressSelector,
       Function<SocketAddress, ClientTransport> clientTransportFunction) {
     this.broker = broker;
     this.clientTransportFunction = clientTransportFunction;
-    this.socketAddress = socketAddress;
+    this.socketAddress = addressSelector.apply(broker);
     this.errorPercentage = new Ewma(5, TimeUnit.SECONDS, 1.0);
     this.selectCount = new AtomicInteger();
     this.onClose = MonoProcessor.create();

--- a/proteus-client/src/test/java/io/netifi/proteus/rsocket/transport/WeightedClientTransportSupplierTest.java
+++ b/proteus-client/src/test/java/io/netifi/proteus/rsocket/transport/WeightedClientTransportSupplierTest.java
@@ -17,7 +17,6 @@ package io.netifi.proteus.rsocket.transport;
 
 import io.rsocket.DuplexConnection;
 import io.rsocket.transport.ClientTransport;
-import java.net.InetSocketAddress;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -37,7 +36,7 @@ public class WeightedClientTransportSupplierTest {
 
     WeightedClientTransportSupplier supplier =
         new WeightedClientTransportSupplier(
-            InetSocketAddress.createUnresolved("localhost", 8081), address -> transport);
+            BrokerAddressSelectors.TCP_ADDRESS, address -> transport);
 
     supplier.select();
     DuplexConnection block = supplier.get().connect().block();


### PR DESCRIPTION
this ensures that our Proteus builder wires up our `DefaultProteusBrokerService` with our the `addressSelector` we customize it with. Otherwise the other constructor, and thus `BrokerAddressSelectors.TCP_ADDRESS,` is used: https://github.com/netifi-proteus/proteus-java/blob/adaa7615c19a41b4c601cc0ca7e91a0c8af4bde5/proteus-client/src/main/java/io/netifi/proteus/DefaultProteusBrokerService.java#L116