### PR TITLE
update rsocket bom to 0.11.18/0.2.14

### DIFF
--- a/ci/travis.sh
+++ b/ci/travis.sh
@@ -9,29 +9,29 @@ echo -e "TRAVIS_PULL_REQUEST=$TRAVIS_PULL_REQUEST"
 if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
     # Pull Request
     echo -e "Build Pull Request #$TRAVIS_PULL_REQUEST => Branch [$TRAVIS_BRANCH]"
-    ./gradlew clean build --stacktrace
+    ./gradlew clean build --stacktrace --refresh-dependencies
 elif [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_BRANCH" == "develop" ] && [ "$TRAVIS_TAG" == "" ]; then
     # Develop Branch
     echo -e 'Build Branch with Snapshot => Branch ['$TRAVIS_BRANCH']'
     export ORG_GRADLE_PROJECT_releaseType=snapshot
-    ./gradlew -PversionSuffix=".BUILD-SNAPSHOT" clean build artifactoryPublish --stacktrace
+    ./gradlew -PversionSuffix=".BUILD-SNAPSHOT" clean build artifactoryPublish --stacktrace --refresh-dependencies
 elif [ "$TRAVIS_PULL_REQUEST" == "false" ] && [[ "$TRAVIS_BRANCH" == release/* ]] && [ "$TRAVIS_TAG" == "" ]; then
     # Release Branch
     echo -e 'Build Branch for Release => Branch ['$TRAVIS_BRANCH']'
-    ./gradlew -PversionSuffix="-RC" clean build artifactoryPublish --stacktrace
+    ./gradlew -PversionSuffix="-RC" clean build artifactoryPublish --stacktrace --refresh-dependencies
 elif [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_BRANCH" == "master" ]; then
     # Master Branch
     echo -e 'Build Master for Release => Branch ['$TRAVIS_BRANCH']'
     export ORG_GRADLE_PROJECT_releaseType=release
-    ./gradlew clean build --stacktrace
+    ./gradlew clean build --stacktrace --refresh-dependencies
 elif [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_TAG" != "" ]; then
     # Tag
     echo -e 'Build Tag for Release => Tag ['$TRAVIS_TAG']'
     export ORG_GRADLE_PROJECT_releaseType=release
-    ./gradlew clean build bintrayUpload --stacktrace
+    ./gradlew clean build bintrayUpload --stacktrace --refresh-dependencies
 else
     # Feature Branch
     echo -e 'Build Branch => Branch ['$TRAVIS_BRANCH']'
     export ORG_GRADLE_PROJECT_releaseType=snapshot
-    ./gradlew clean -PversionSuffix=".BUILD-SNAPSHOT" build artifactoryPublish --stacktrace
+    ./gradlew clean -PversionSuffix=".BUILD-SNAPSHOT" build artifactoryPublish --stacktrace --refresh-dependencies
 fi

--- a/proteus-auth/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/proteus-auth/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -17,9 +17,9 @@ io.netty:netty-transport:4.1.33.Final
 io.projectreactor.netty:reactor-netty:0.8.5.RELEASE
 io.projectreactor:reactor-core:3.2.6.RELEASE
 io.projectreactor:reactor-test:3.2.6.RELEASE
-io.rsocket:rsocket-core:0.11.16
-io.rsocket:rsocket-transport-local:0.11.16
-io.rsocket:rsocket-transport-netty:0.11.16
+io.rsocket:rsocket-core:0.11.18
+io.rsocket:rsocket-transport-local:0.11.18
+io.rsocket:rsocket-transport-netty:0.11.18
 javax.inject:javax.inject:1
 junit:junit:4.12
 net.bytebuddy:byte-buddy-agent:1.9.7

--- a/proteus-auth/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/proteus-auth/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -17,9 +17,9 @@ io.netty:netty-transport:4.1.33.Final
 io.projectreactor.netty:reactor-netty:0.8.5.RELEASE
 io.projectreactor:reactor-core:3.2.6.RELEASE
 io.projectreactor:reactor-test:3.2.6.RELEASE
-io.rsocket:rsocket-core:0.11.16
-io.rsocket:rsocket-transport-local:0.11.16
-io.rsocket:rsocket-transport-netty:0.11.16
+io.rsocket:rsocket-core:0.11.18
+io.rsocket:rsocket-transport-local:0.11.18
+io.rsocket:rsocket-transport-netty:0.11.18
 javax.inject:javax.inject:1
 junit:junit:4.12
 net.bytebuddy:byte-buddy-agent:1.9.7

--- a/proteus-broker-info-idl/gradle/dependency-locks/testCompile.lockfile
+++ b/proteus-broker-info-idl/gradle/dependency-locks/testCompile.lockfile
@@ -17,9 +17,9 @@ io.netty:netty-transport:4.1.33.Final
 io.projectreactor.netty:reactor-netty:0.8.5.RELEASE
 io.projectreactor:reactor-core:3.2.6.RELEASE
 io.projectreactor:reactor-test:3.2.6.RELEASE
-io.rsocket:rsocket-core:0.11.16
-io.rsocket:rsocket-transport-local:0.11.16
-io.rsocket:rsocket-transport-netty:0.11.16
+io.rsocket:rsocket-core:0.11.18
+io.rsocket:rsocket-transport-local:0.11.18
+io.rsocket:rsocket-transport-netty:0.11.18
 javax.inject:javax.inject:1
 junit:junit:4.12
 net.bytebuddy:byte-buddy-agent:1.9.7

--- a/proteus-broker-info-idl/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/proteus-broker-info-idl/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -17,9 +17,9 @@ io.netty:netty-transport:4.1.33.Final
 io.projectreactor.netty:reactor-netty:0.8.5.RELEASE
 io.projectreactor:reactor-core:3.2.6.RELEASE
 io.projectreactor:reactor-test:3.2.6.RELEASE
-io.rsocket:rsocket-core:0.11.16
-io.rsocket:rsocket-transport-local:0.11.16
-io.rsocket:rsocket-transport-netty:0.11.16
+io.rsocket:rsocket-core:0.11.18
+io.rsocket:rsocket-transport-local:0.11.18
+io.rsocket:rsocket-transport-netty:0.11.18
 javax.inject:javax.inject:1
 junit:junit:4.12
 net.bytebuddy:byte-buddy-agent:1.9.7

--- a/proteus-broker-mgmt-idl/gradle/dependency-locks/testCompile.lockfile
+++ b/proteus-broker-mgmt-idl/gradle/dependency-locks/testCompile.lockfile
@@ -17,9 +17,9 @@ io.netty:netty-transport:4.1.33.Final
 io.projectreactor.netty:reactor-netty:0.8.5.RELEASE
 io.projectreactor:reactor-core:3.2.6.RELEASE
 io.projectreactor:reactor-test:3.2.6.RELEASE
-io.rsocket:rsocket-core:0.11.16
-io.rsocket:rsocket-transport-local:0.11.16
-io.rsocket:rsocket-transport-netty:0.11.16
+io.rsocket:rsocket-core:0.11.18
+io.rsocket:rsocket-transport-local:0.11.18
+io.rsocket:rsocket-transport-netty:0.11.18
 javax.inject:javax.inject:1
 junit:junit:4.12
 net.bytebuddy:byte-buddy-agent:1.9.7

--- a/proteus-broker-mgmt-idl/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/proteus-broker-mgmt-idl/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -17,9 +17,9 @@ io.netty:netty-transport:4.1.33.Final
 io.projectreactor.netty:reactor-netty:0.8.5.RELEASE
 io.projectreactor:reactor-core:3.2.6.RELEASE
 io.projectreactor:reactor-test:3.2.6.RELEASE
-io.rsocket:rsocket-core:0.11.16
-io.rsocket:rsocket-transport-local:0.11.16
-io.rsocket:rsocket-transport-netty:0.11.16
+io.rsocket:rsocket-core:0.11.18
+io.rsocket:rsocket-transport-local:0.11.18
+io.rsocket:rsocket-transport-netty:0.11.18
 javax.inject:javax.inject:1
 junit:junit:4.12
 net.bytebuddy:byte-buddy-agent:1.9.7

--- a/proteus-client/gradle/dependency-locks/compile.lockfile
+++ b/proteus-client/gradle/dependency-locks/compile.lockfile
@@ -20,9 +20,9 @@ io.netty:netty-transport:4.1.33.Final
 io.opentracing:opentracing-api:0.31.0
 io.projectreactor.netty:reactor-netty:0.8.5.RELEASE
 io.projectreactor:reactor-core:3.2.6.RELEASE
-io.rsocket.rpc:rsocket-rpc-core:0.2.13
-io.rsocket:rsocket-core:0.11.16
-io.rsocket:rsocket-transport-netty:0.11.16
+io.rsocket.rpc:rsocket-rpc-core:0.2.14
+io.rsocket:rsocket-core:0.11.18
+io.rsocket:rsocket-transport-netty:0.11.18
 javax.annotation:javax.annotation-api:1.3.2
 javax.inject:javax.inject:1
 org.hdrhistogram:HdrHistogram:2.1.10

--- a/proteus-client/gradle/dependency-locks/compileClasspath.lockfile
+++ b/proteus-client/gradle/dependency-locks/compileClasspath.lockfile
@@ -20,9 +20,9 @@ io.netty:netty-transport:4.1.33.Final
 io.opentracing:opentracing-api:0.31.0
 io.projectreactor.netty:reactor-netty:0.8.5.RELEASE
 io.projectreactor:reactor-core:3.2.6.RELEASE
-io.rsocket.rpc:rsocket-rpc-core:0.2.13
-io.rsocket:rsocket-core:0.11.16
-io.rsocket:rsocket-transport-netty:0.11.16
+io.rsocket.rpc:rsocket-rpc-core:0.2.14
+io.rsocket:rsocket-core:0.11.18
+io.rsocket:rsocket-transport-netty:0.11.18
 javax.annotation:javax.annotation-api:1.3.2
 javax.inject:javax.inject:1
 org.hdrhistogram:HdrHistogram:2.1.10

--- a/proteus-client/gradle/dependency-locks/protobufToolsLocator_rsocketRpc.lockfile
+++ b/proteus-client/gradle/dependency-locks/protobufToolsLocator_rsocketRpc.lockfile
@@ -1,4 +1,4 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-io.rsocket.rpc:rsocket-rpc-protobuf:0.2.13
+io.rsocket.rpc:rsocket-rpc-protobuf:0.2.14

--- a/proteus-client/gradle/dependency-locks/testCompile.lockfile
+++ b/proteus-client/gradle/dependency-locks/testCompile.lockfile
@@ -41,11 +41,11 @@ io.projectreactor.addons:reactor-adapter:3.2.2.RELEASE
 io.projectreactor.netty:reactor-netty:0.8.5.RELEASE
 io.projectreactor:reactor-core:3.2.6.RELEASE
 io.projectreactor:reactor-test:3.2.6.RELEASE
-io.rsocket.rpc:rsocket-rpc-core:0.2.13
-io.rsocket.rpc:rsocket-rpc-protobuf:0.2.13
-io.rsocket:rsocket-core:0.11.16
-io.rsocket:rsocket-transport-local:0.11.16
-io.rsocket:rsocket-transport-netty:0.11.16
+io.rsocket.rpc:rsocket-rpc-core:0.2.14
+io.rsocket.rpc:rsocket-rpc-protobuf:0.2.14
+io.rsocket:rsocket-core:0.11.18
+io.rsocket:rsocket-transport-local:0.11.18
+io.rsocket:rsocket-transport-netty:0.11.18
 io.zipkin.brave:brave:5.6.1
 io.zipkin.reporter2:zipkin-reporter:2.7.14
 io.zipkin.zipkin2:zipkin:2.12.0

--- a/proteus-client/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/proteus-client/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -41,11 +41,11 @@ io.projectreactor.addons:reactor-adapter:3.2.2.RELEASE
 io.projectreactor.netty:reactor-netty:0.8.5.RELEASE
 io.projectreactor:reactor-core:3.2.6.RELEASE
 io.projectreactor:reactor-test:3.2.6.RELEASE
-io.rsocket.rpc:rsocket-rpc-core:0.2.13
-io.rsocket.rpc:rsocket-rpc-protobuf:0.2.13
-io.rsocket:rsocket-core:0.11.16
-io.rsocket:rsocket-transport-local:0.11.16
-io.rsocket:rsocket-transport-netty:0.11.16
+io.rsocket.rpc:rsocket-rpc-core:0.2.14
+io.rsocket.rpc:rsocket-rpc-protobuf:0.2.14
+io.rsocket:rsocket-core:0.11.18
+io.rsocket:rsocket-transport-local:0.11.18
+io.rsocket:rsocket-transport-netty:0.11.18
 io.zipkin.brave:brave:5.6.1
 io.zipkin.reporter2:zipkin-reporter:2.7.14
 io.zipkin.zipkin2:zipkin:2.12.0

--- a/proteus-client/gradle/dependency-locks/testProtobuf.lockfile
+++ b/proteus-client/gradle/dependency-locks/testProtobuf.lockfile
@@ -1,4 +1,4 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-io.rsocket.rpc:rsocket-rpc-protobuf-idl:0.2.13
+io.rsocket.rpc:rsocket-rpc-protobuf-idl:0.2.14

--- a/proteus-client/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/proteus-client/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -41,11 +41,11 @@ io.projectreactor.addons:reactor-adapter:3.2.2.RELEASE
 io.projectreactor.netty:reactor-netty:0.8.5.RELEASE
 io.projectreactor:reactor-core:3.2.6.RELEASE
 io.projectreactor:reactor-test:3.2.6.RELEASE
-io.rsocket.rpc:rsocket-rpc-core:0.2.13
-io.rsocket.rpc:rsocket-rpc-protobuf:0.2.13
-io.rsocket:rsocket-core:0.11.16
-io.rsocket:rsocket-transport-local:0.11.16
-io.rsocket:rsocket-transport-netty:0.11.16
+io.rsocket.rpc:rsocket-rpc-core:0.2.14
+io.rsocket.rpc:rsocket-rpc-protobuf:0.2.14
+io.rsocket:rsocket-core:0.11.18
+io.rsocket:rsocket-transport-local:0.11.18
+io.rsocket:rsocket-transport-netty:0.11.18
 io.zipkin.brave:brave:5.6.1
 io.zipkin.reporter2:zipkin-reporter:2.7.14
 io.zipkin.zipkin2:zipkin:2.12.0

--- a/proteus-client/src/main/java/io/netifi/proteus/rsocket/NamedRSocketServiceWrapper.java
+++ b/proteus-client/src/main/java/io/netifi/proteus/rsocket/NamedRSocketServiceWrapper.java
@@ -65,11 +65,6 @@ public class NamedRSocketServiceWrapper extends AbstractUnwrappingRSocket
   }
 
   @Override
-  public final Flux<Payload> requestChannel(Payload payload, Publisher<Payload> publisher) {
-    return requestChannel(payload, Flux.from(publisher));
-  }
-
-  @Override
   public final Flux<Payload> requestChannel(Payload payload, Flux<Payload> payloads) {
     if (source instanceof ResponderRSocket) {
       ResponderRSocket responderRSocket = (ResponderRSocket) source;

--- a/proteus-client/src/main/java/io/netifi/proteus/rsocket/NamedRSocketServiceWrapper.java
+++ b/proteus-client/src/main/java/io/netifi/proteus/rsocket/NamedRSocketServiceWrapper.java
@@ -23,7 +23,6 @@ import io.rsocket.rpc.RSocketRpcService;
 import io.rsocket.rpc.frames.Metadata;
 import io.rsocket.util.ByteBufPayload;
 import io.rsocket.util.RSocketProxy;
-import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 
 public class NamedRSocketServiceWrapper extends AbstractUnwrappingRSocket

--- a/proteus-client/src/main/java/io/netifi/proteus/rsocket/NamedRSocketServiceWrapper.java
+++ b/proteus-client/src/main/java/io/netifi/proteus/rsocket/NamedRSocketServiceWrapper.java
@@ -66,13 +66,17 @@ public class NamedRSocketServiceWrapper extends AbstractUnwrappingRSocket
 
   @Override
   public final Flux<Payload> requestChannel(Payload payload, Publisher<Payload> publisher) {
+    return requestChannel(payload, Flux.from(publisher));
+  }
+
+  @Override
+  public final Flux<Payload> requestChannel(Payload payload, Flux<Payload> payloads) {
     if (source instanceof ResponderRSocket) {
       ResponderRSocket responderRSocket = (ResponderRSocket) source;
 
-      return responderRSocket.requestChannel(
-          unwrap(payload), Flux.from(publisher).map(this::unwrap));
+      return responderRSocket.requestChannel(unwrap(payload), payloads.map(this::unwrap));
     }
 
-    return super.requestChannel(publisher);
+    return super.requestChannel(payloads);
   }
 }

--- a/proteus-common/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/proteus-common/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -17,9 +17,9 @@ io.netty:netty-transport:4.1.33.Final
 io.projectreactor.netty:reactor-netty:0.8.5.RELEASE
 io.projectreactor:reactor-core:3.2.6.RELEASE
 io.projectreactor:reactor-test:3.2.6.RELEASE
-io.rsocket:rsocket-core:0.11.16
-io.rsocket:rsocket-transport-local:0.11.16
-io.rsocket:rsocket-transport-netty:0.11.16
+io.rsocket:rsocket-core:0.11.18
+io.rsocket:rsocket-transport-local:0.11.18
+io.rsocket:rsocket-transport-netty:0.11.18
 javax.inject:javax.inject:1
 junit:junit:4.12
 net.bytebuddy:byte-buddy-agent:1.9.7

--- a/proteus-common/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/proteus-common/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -17,9 +17,9 @@ io.netty:netty-transport:4.1.33.Final
 io.projectreactor.netty:reactor-netty:0.8.5.RELEASE
 io.projectreactor:reactor-core:3.2.6.RELEASE
 io.projectreactor:reactor-test:3.2.6.RELEASE
-io.rsocket:rsocket-core:0.11.16
-io.rsocket:rsocket-transport-local:0.11.16
-io.rsocket:rsocket-transport-netty:0.11.16
+io.rsocket:rsocket-core:0.11.18
+io.rsocket:rsocket-transport-local:0.11.18
+io.rsocket:rsocket-transport-netty:0.11.18
 javax.inject:javax.inject:1
 junit:junit:4.12
 net.bytebuddy:byte-buddy-agent:1.9.7

--- a/proteus-discovery-aws/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/proteus-discovery-aws/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -20,9 +20,9 @@ io.netty:netty-transport:4.1.33.Final
 io.projectreactor.netty:reactor-netty:0.8.5.RELEASE
 io.projectreactor:reactor-core:3.2.6.RELEASE
 io.projectreactor:reactor-test:3.2.6.RELEASE
-io.rsocket:rsocket-core:0.11.16
-io.rsocket:rsocket-transport-local:0.11.16
-io.rsocket:rsocket-transport-netty:0.11.16
+io.rsocket:rsocket-core:0.11.18
+io.rsocket:rsocket-transport-local:0.11.18
+io.rsocket:rsocket-transport-netty:0.11.18
 javax.inject:javax.inject:1
 junit:junit:4.12
 net.bytebuddy:byte-buddy-agent:1.9.7

--- a/proteus-discovery-aws/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/proteus-discovery-aws/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -24,9 +24,9 @@ io.netty:netty-transport:4.1.33.Final
 io.projectreactor.netty:reactor-netty:0.8.5.RELEASE
 io.projectreactor:reactor-core:3.2.6.RELEASE
 io.projectreactor:reactor-test:3.2.6.RELEASE
-io.rsocket:rsocket-core:0.11.16
-io.rsocket:rsocket-transport-local:0.11.16
-io.rsocket:rsocket-transport-netty:0.11.16
+io.rsocket:rsocket-core:0.11.18
+io.rsocket:rsocket-transport-local:0.11.18
+io.rsocket:rsocket-transport-netty:0.11.18
 javax.inject:javax.inject:1
 junit:junit:4.12
 net.bytebuddy:byte-buddy-agent:1.9.7

--- a/proteus-discovery-consul/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/proteus-discovery-consul/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -33,9 +33,9 @@ io.netty:netty-transport:4.1.33.Final
 io.projectreactor.netty:reactor-netty:0.8.5.RELEASE
 io.projectreactor:reactor-core:3.2.6.RELEASE
 io.projectreactor:reactor-test:3.2.6.RELEASE
-io.rsocket:rsocket-core:0.11.16
-io.rsocket:rsocket-transport-local:0.11.16
-io.rsocket:rsocket-transport-netty:0.11.16
+io.rsocket:rsocket-core:0.11.18
+io.rsocket:rsocket-transport-local:0.11.18
+io.rsocket:rsocket-transport-netty:0.11.18
 javax.inject:javax.inject:1
 junit:junit:4.12
 net.bytebuddy:byte-buddy-agent:1.9.7

--- a/proteus-discovery-consul/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/proteus-discovery-consul/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -33,9 +33,9 @@ io.netty:netty-transport:4.1.33.Final
 io.projectreactor.netty:reactor-netty:0.8.5.RELEASE
 io.projectreactor:reactor-core:3.2.6.RELEASE
 io.projectreactor:reactor-test:3.2.6.RELEASE
-io.rsocket:rsocket-core:0.11.16
-io.rsocket:rsocket-transport-local:0.11.16
-io.rsocket:rsocket-transport-netty:0.11.16
+io.rsocket:rsocket-core:0.11.18
+io.rsocket:rsocket-transport-local:0.11.18
+io.rsocket:rsocket-transport-netty:0.11.18
 javax.inject:javax.inject:1
 junit:junit:4.12
 net.bytebuddy:byte-buddy-agent:1.9.7

--- a/proteus-discovery-kubernetes/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/proteus-discovery-kubernetes/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -37,9 +37,9 @@ io.netty:netty-transport:4.1.33.Final
 io.projectreactor.netty:reactor-netty:0.8.5.RELEASE
 io.projectreactor:reactor-core:3.2.6.RELEASE
 io.projectreactor:reactor-test:3.2.6.RELEASE
-io.rsocket:rsocket-core:0.11.16
-io.rsocket:rsocket-transport-local:0.11.16
-io.rsocket:rsocket-transport-netty:0.11.16
+io.rsocket:rsocket-core:0.11.18
+io.rsocket:rsocket-transport-local:0.11.18
+io.rsocket:rsocket-transport-netty:0.11.18
 io.sundr:builder-annotations:0.9.2
 io.sundr:resourcecify-annotations:0.9.2
 io.sundr:sundr-codegen:0.9.2

--- a/proteus-discovery-kubernetes/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/proteus-discovery-kubernetes/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -37,9 +37,9 @@ io.netty:netty-transport:4.1.33.Final
 io.projectreactor.netty:reactor-netty:0.8.5.RELEASE
 io.projectreactor:reactor-core:3.2.6.RELEASE
 io.projectreactor:reactor-test:3.2.6.RELEASE
-io.rsocket:rsocket-core:0.11.16
-io.rsocket:rsocket-transport-local:0.11.16
-io.rsocket:rsocket-transport-netty:0.11.16
+io.rsocket:rsocket-core:0.11.18
+io.rsocket:rsocket-transport-local:0.11.18
+io.rsocket:rsocket-transport-netty:0.11.18
 io.sundr:builder-annotations:0.9.2
 io.sundr:resourcecify-annotations:0.9.2
 io.sundr:sundr-codegen:0.9.2

--- a/proteus-discovery/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/proteus-discovery/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -17,9 +17,9 @@ io.netty:netty-transport:4.1.33.Final
 io.projectreactor.netty:reactor-netty:0.8.5.RELEASE
 io.projectreactor:reactor-core:3.2.6.RELEASE
 io.projectreactor:reactor-test:3.2.6.RELEASE
-io.rsocket:rsocket-core:0.11.16
-io.rsocket:rsocket-transport-local:0.11.16
-io.rsocket:rsocket-transport-netty:0.11.16
+io.rsocket:rsocket-core:0.11.18
+io.rsocket:rsocket-transport-local:0.11.18
+io.rsocket:rsocket-transport-netty:0.11.18
 javax.inject:javax.inject:1
 junit:junit:4.12
 net.bytebuddy:byte-buddy-agent:1.9.7

--- a/proteus-discovery/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/proteus-discovery/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -17,9 +17,9 @@ io.netty:netty-transport:4.1.33.Final
 io.projectreactor.netty:reactor-netty:0.8.5.RELEASE
 io.projectreactor:reactor-core:3.2.6.RELEASE
 io.projectreactor:reactor-test:3.2.6.RELEASE
-io.rsocket:rsocket-core:0.11.16
-io.rsocket:rsocket-transport-local:0.11.16
-io.rsocket:rsocket-transport-netty:0.11.16
+io.rsocket:rsocket-core:0.11.18
+io.rsocket:rsocket-transport-local:0.11.18
+io.rsocket:rsocket-transport-netty:0.11.18
 javax.inject:javax.inject:1
 junit:junit:4.12
 net.bytebuddy:byte-buddy-agent:1.9.7

--- a/proteus-frames/gradle/dependency-locks/compileClasspath.lockfile
+++ b/proteus-frames/gradle/dependency-locks/compileClasspath.lockfile
@@ -4,6 +4,6 @@
 io.netty:netty-buffer:4.1.33.Final
 io.netty:netty-common:4.1.33.Final
 io.projectreactor:reactor-core:3.2.6.RELEASE
-io.rsocket:rsocket-core:0.11.16
+io.rsocket:rsocket-core:0.11.18
 javax.inject:javax.inject:1
 org.reactivestreams:reactive-streams:1.0.2

--- a/proteus-frames/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/proteus-frames/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -17,9 +17,9 @@ io.netty:netty-transport:4.1.33.Final
 io.projectreactor.netty:reactor-netty:0.8.5.RELEASE
 io.projectreactor:reactor-core:3.2.6.RELEASE
 io.projectreactor:reactor-test:3.2.6.RELEASE
-io.rsocket:rsocket-core:0.11.16
-io.rsocket:rsocket-transport-local:0.11.16
-io.rsocket:rsocket-transport-netty:0.11.16
+io.rsocket:rsocket-core:0.11.18
+io.rsocket:rsocket-transport-local:0.11.18
+io.rsocket:rsocket-transport-netty:0.11.18
 javax.inject:javax.inject:1
 junit:junit:4.12
 net.bytebuddy:byte-buddy-agent:1.9.7

--- a/proteus-frames/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/proteus-frames/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -17,9 +17,9 @@ io.netty:netty-transport:4.1.33.Final
 io.projectreactor.netty:reactor-netty:0.8.5.RELEASE
 io.projectreactor:reactor-core:3.2.6.RELEASE
 io.projectreactor:reactor-test:3.2.6.RELEASE
-io.rsocket:rsocket-core:0.11.16
-io.rsocket:rsocket-transport-local:0.11.16
-io.rsocket:rsocket-transport-netty:0.11.16
+io.rsocket:rsocket-core:0.11.18
+io.rsocket:rsocket-transport-local:0.11.18
+io.rsocket:rsocket-transport-netty:0.11.18
 javax.inject:javax.inject:1
 junit:junit:4.12
 net.bytebuddy:byte-buddy-agent:1.9.7

--- a/proteus-metrics-micrometer/gradle/dependency-locks/compile.lockfile
+++ b/proteus-metrics-micrometer/gradle/dependency-locks/compile.lockfile
@@ -28,10 +28,10 @@ io.netty:netty-transport:4.1.33.Final
 io.opentracing:opentracing-api:0.31.0
 io.projectreactor.netty:reactor-netty:0.8.5.RELEASE
 io.projectreactor:reactor-core:3.2.6.RELEASE
-io.rsocket.rpc:rsocket-rpc-core:0.2.13
-io.rsocket.rpc:rsocket-rpc-protobuf:0.2.13
-io.rsocket:rsocket-core:0.11.16
-io.rsocket:rsocket-transport-netty:0.11.16
+io.rsocket.rpc:rsocket-rpc-core:0.2.14
+io.rsocket.rpc:rsocket-rpc-protobuf:0.2.14
+io.rsocket:rsocket-core:0.11.18
+io.rsocket:rsocket-transport-netty:0.11.18
 javax.annotation:javax.annotation-api:1.3.2
 javax.inject:javax.inject:1
 org.hdrhistogram:HdrHistogram:2.1.10

--- a/proteus-metrics-micrometer/gradle/dependency-locks/compileClasspath.lockfile
+++ b/proteus-metrics-micrometer/gradle/dependency-locks/compileClasspath.lockfile
@@ -28,10 +28,10 @@ io.netty:netty-transport:4.1.33.Final
 io.opentracing:opentracing-api:0.31.0
 io.projectreactor.netty:reactor-netty:0.8.5.RELEASE
 io.projectreactor:reactor-core:3.2.6.RELEASE
-io.rsocket.rpc:rsocket-rpc-core:0.2.13
-io.rsocket.rpc:rsocket-rpc-protobuf:0.2.13
-io.rsocket:rsocket-core:0.11.16
-io.rsocket:rsocket-transport-netty:0.11.16
+io.rsocket.rpc:rsocket-rpc-core:0.2.14
+io.rsocket.rpc:rsocket-rpc-protobuf:0.2.14
+io.rsocket:rsocket-core:0.11.18
+io.rsocket:rsocket-transport-netty:0.11.18
 javax.annotation:javax.annotation-api:1.3.2
 javax.inject:javax.inject:1
 org.hdrhistogram:HdrHistogram:2.1.10

--- a/proteus-metrics-micrometer/gradle/dependency-locks/protobuf.lockfile
+++ b/proteus-metrics-micrometer/gradle/dependency-locks/protobuf.lockfile
@@ -1,4 +1,4 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-io.rsocket.rpc:rsocket-rpc-metrics-idl:0.2.13
+io.rsocket.rpc:rsocket-rpc-metrics-idl:0.2.14

--- a/proteus-metrics-micrometer/gradle/dependency-locks/protobufToolsLocator_rsocketRpc.lockfile
+++ b/proteus-metrics-micrometer/gradle/dependency-locks/protobufToolsLocator_rsocketRpc.lockfile
@@ -1,4 +1,4 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-io.rsocket.rpc:rsocket-rpc-protobuf:0.2.13
+io.rsocket.rpc:rsocket-rpc-protobuf:0.2.14

--- a/proteus-metrics-micrometer/gradle/dependency-locks/testCompile.lockfile
+++ b/proteus-metrics-micrometer/gradle/dependency-locks/testCompile.lockfile
@@ -29,11 +29,11 @@ io.opentracing:opentracing-api:0.31.0
 io.projectreactor.netty:reactor-netty:0.8.5.RELEASE
 io.projectreactor:reactor-core:3.2.6.RELEASE
 io.projectreactor:reactor-test:3.2.6.RELEASE
-io.rsocket.rpc:rsocket-rpc-core:0.2.13
-io.rsocket.rpc:rsocket-rpc-protobuf:0.2.13
-io.rsocket:rsocket-core:0.11.16
-io.rsocket:rsocket-transport-local:0.11.16
-io.rsocket:rsocket-transport-netty:0.11.16
+io.rsocket.rpc:rsocket-rpc-core:0.2.14
+io.rsocket.rpc:rsocket-rpc-protobuf:0.2.14
+io.rsocket:rsocket-core:0.11.18
+io.rsocket:rsocket-transport-local:0.11.18
+io.rsocket:rsocket-transport-netty:0.11.18
 javax.annotation:javax.annotation-api:1.3.2
 javax.inject:javax.inject:1
 junit:junit:4.12

--- a/proteus-metrics-micrometer/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/proteus-metrics-micrometer/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -29,11 +29,11 @@ io.opentracing:opentracing-api:0.31.0
 io.projectreactor.netty:reactor-netty:0.8.5.RELEASE
 io.projectreactor:reactor-core:3.2.6.RELEASE
 io.projectreactor:reactor-test:3.2.6.RELEASE
-io.rsocket.rpc:rsocket-rpc-core:0.2.13
-io.rsocket.rpc:rsocket-rpc-protobuf:0.2.13
-io.rsocket:rsocket-core:0.11.16
-io.rsocket:rsocket-transport-local:0.11.16
-io.rsocket:rsocket-transport-netty:0.11.16
+io.rsocket.rpc:rsocket-rpc-core:0.2.14
+io.rsocket.rpc:rsocket-rpc-protobuf:0.2.14
+io.rsocket:rsocket-core:0.11.18
+io.rsocket:rsocket-transport-local:0.11.18
+io.rsocket:rsocket-transport-netty:0.11.18
 javax.annotation:javax.annotation-api:1.3.2
 javax.inject:javax.inject:1
 junit:junit:4.12

--- a/proteus-metrics-prometheus/gradle/dependency-locks/compile.lockfile
+++ b/proteus-metrics-prometheus/gradle/dependency-locks/compile.lockfile
@@ -23,10 +23,10 @@ io.projectreactor.netty:reactor-netty:0.8.5.RELEASE
 io.projectreactor:reactor-core:3.2.6.RELEASE
 io.prometheus:simpleclient:0.5.0
 io.prometheus:simpleclient_common:0.5.0
-io.rsocket.rpc:rsocket-rpc-core:0.2.13
-io.rsocket.rpc:rsocket-rpc-protobuf:0.2.13
-io.rsocket:rsocket-core:0.11.16
-io.rsocket:rsocket-transport-netty:0.11.16
+io.rsocket.rpc:rsocket-rpc-core:0.2.14
+io.rsocket.rpc:rsocket-rpc-protobuf:0.2.14
+io.rsocket:rsocket-core:0.11.18
+io.rsocket:rsocket-transport-netty:0.11.18
 javax.annotation:javax.annotation-api:1.3.2
 javax.inject:javax.inject:1
 org.hdrhistogram:HdrHistogram:2.1.10

--- a/proteus-metrics-prometheus/gradle/dependency-locks/compileClasspath.lockfile
+++ b/proteus-metrics-prometheus/gradle/dependency-locks/compileClasspath.lockfile
@@ -23,10 +23,10 @@ io.projectreactor.netty:reactor-netty:0.8.5.RELEASE
 io.projectreactor:reactor-core:3.2.6.RELEASE
 io.prometheus:simpleclient:0.5.0
 io.prometheus:simpleclient_common:0.5.0
-io.rsocket.rpc:rsocket-rpc-core:0.2.13
-io.rsocket.rpc:rsocket-rpc-protobuf:0.2.13
-io.rsocket:rsocket-core:0.11.16
-io.rsocket:rsocket-transport-netty:0.11.16
+io.rsocket.rpc:rsocket-rpc-core:0.2.14
+io.rsocket.rpc:rsocket-rpc-protobuf:0.2.14
+io.rsocket:rsocket-core:0.11.18
+io.rsocket:rsocket-transport-netty:0.11.18
 javax.annotation:javax.annotation-api:1.3.2
 javax.inject:javax.inject:1
 org.hdrhistogram:HdrHistogram:2.1.10

--- a/proteus-metrics-prometheus/gradle/dependency-locks/protobuf.lockfile
+++ b/proteus-metrics-prometheus/gradle/dependency-locks/protobuf.lockfile
@@ -1,4 +1,4 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-io.rsocket.rpc:rsocket-rpc-metrics-idl:0.2.13
+io.rsocket.rpc:rsocket-rpc-metrics-idl:0.2.14

--- a/proteus-metrics-prometheus/gradle/dependency-locks/protobufToolsLocator_rsocketRpc.lockfile
+++ b/proteus-metrics-prometheus/gradle/dependency-locks/protobufToolsLocator_rsocketRpc.lockfile
@@ -1,4 +1,4 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-io.rsocket.rpc:rsocket-rpc-protobuf:0.2.13
+io.rsocket.rpc:rsocket-rpc-protobuf:0.2.14

--- a/proteus-metrics-prometheus/gradle/dependency-locks/testCompile.lockfile
+++ b/proteus-metrics-prometheus/gradle/dependency-locks/testCompile.lockfile
@@ -24,11 +24,11 @@ io.projectreactor:reactor-core:3.2.6.RELEASE
 io.projectreactor:reactor-test:3.2.6.RELEASE
 io.prometheus:simpleclient:0.5.0
 io.prometheus:simpleclient_common:0.5.0
-io.rsocket.rpc:rsocket-rpc-core:0.2.13
-io.rsocket.rpc:rsocket-rpc-protobuf:0.2.13
-io.rsocket:rsocket-core:0.11.16
-io.rsocket:rsocket-transport-local:0.11.16
-io.rsocket:rsocket-transport-netty:0.11.16
+io.rsocket.rpc:rsocket-rpc-core:0.2.14
+io.rsocket.rpc:rsocket-rpc-protobuf:0.2.14
+io.rsocket:rsocket-core:0.11.18
+io.rsocket:rsocket-transport-local:0.11.18
+io.rsocket:rsocket-transport-netty:0.11.18
 javax.annotation:javax.annotation-api:1.3.2
 javax.inject:javax.inject:1
 junit:junit:4.12

--- a/proteus-metrics-prometheus/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/proteus-metrics-prometheus/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -24,11 +24,11 @@ io.projectreactor:reactor-core:3.2.6.RELEASE
 io.projectreactor:reactor-test:3.2.6.RELEASE
 io.prometheus:simpleclient:0.5.0
 io.prometheus:simpleclient_common:0.5.0
-io.rsocket.rpc:rsocket-rpc-core:0.2.13
-io.rsocket.rpc:rsocket-rpc-protobuf:0.2.13
-io.rsocket:rsocket-core:0.11.16
-io.rsocket:rsocket-transport-local:0.11.16
-io.rsocket:rsocket-transport-netty:0.11.16
+io.rsocket.rpc:rsocket-rpc-core:0.2.14
+io.rsocket.rpc:rsocket-rpc-protobuf:0.2.14
+io.rsocket:rsocket-core:0.11.18
+io.rsocket:rsocket-transport-local:0.11.18
+io.rsocket:rsocket-transport-netty:0.11.18
 javax.annotation:javax.annotation-api:1.3.2
 javax.inject:javax.inject:1
 junit:junit:4.12

--- a/proteus-tracing-idl/gradle/dependency-locks/testCompile.lockfile
+++ b/proteus-tracing-idl/gradle/dependency-locks/testCompile.lockfile
@@ -17,9 +17,9 @@ io.netty:netty-transport:4.1.33.Final
 io.projectreactor.netty:reactor-netty:0.8.5.RELEASE
 io.projectreactor:reactor-core:3.2.6.RELEASE
 io.projectreactor:reactor-test:3.2.6.RELEASE
-io.rsocket:rsocket-core:0.11.16
-io.rsocket:rsocket-transport-local:0.11.16
-io.rsocket:rsocket-transport-netty:0.11.16
+io.rsocket:rsocket-core:0.11.18
+io.rsocket:rsocket-transport-local:0.11.18
+io.rsocket:rsocket-transport-netty:0.11.18
 javax.inject:javax.inject:1
 junit:junit:4.12
 net.bytebuddy:byte-buddy-agent:1.9.7

--- a/proteus-tracing-idl/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/proteus-tracing-idl/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -17,9 +17,9 @@ io.netty:netty-transport:4.1.33.Final
 io.projectreactor.netty:reactor-netty:0.8.5.RELEASE
 io.projectreactor:reactor-core:3.2.6.RELEASE
 io.projectreactor:reactor-test:3.2.6.RELEASE
-io.rsocket:rsocket-core:0.11.16
-io.rsocket:rsocket-transport-local:0.11.16
-io.rsocket:rsocket-transport-netty:0.11.16
+io.rsocket:rsocket-core:0.11.18
+io.rsocket:rsocket-transport-local:0.11.18
+io.rsocket:rsocket-transport-netty:0.11.18
 javax.inject:javax.inject:1
 junit:junit:4.12
 net.bytebuddy:byte-buddy-agent:1.9.7

--- a/proteus-tracing-openzipkin/gradle/dependency-locks/compile.lockfile
+++ b/proteus-tracing-openzipkin/gradle/dependency-locks/compile.lockfile
@@ -35,10 +35,10 @@ io.opentracing:opentracing-api:0.31.0
 io.projectreactor.addons:reactor-adapter:3.2.2.RELEASE
 io.projectreactor.netty:reactor-netty:0.8.5.RELEASE
 io.projectreactor:reactor-core:3.2.6.RELEASE
-io.rsocket.rpc:rsocket-rpc-core:0.2.13
-io.rsocket.rpc:rsocket-rpc-protobuf:0.2.13
-io.rsocket:rsocket-core:0.11.16
-io.rsocket:rsocket-transport-netty:0.11.16
+io.rsocket.rpc:rsocket-rpc-core:0.2.14
+io.rsocket.rpc:rsocket-rpc-protobuf:0.2.14
+io.rsocket:rsocket-core:0.11.18
+io.rsocket:rsocket-transport-netty:0.11.18
 io.zipkin.brave:brave:5.6.1
 io.zipkin.reporter2:zipkin-reporter:2.7.14
 io.zipkin.zipkin2:zipkin:2.12.0

--- a/proteus-tracing-openzipkin/gradle/dependency-locks/compileClasspath.lockfile
+++ b/proteus-tracing-openzipkin/gradle/dependency-locks/compileClasspath.lockfile
@@ -35,10 +35,10 @@ io.opentracing:opentracing-api:0.31.0
 io.projectreactor.addons:reactor-adapter:3.2.2.RELEASE
 io.projectreactor.netty:reactor-netty:0.8.5.RELEASE
 io.projectreactor:reactor-core:3.2.6.RELEASE
-io.rsocket.rpc:rsocket-rpc-core:0.2.13
-io.rsocket.rpc:rsocket-rpc-protobuf:0.2.13
-io.rsocket:rsocket-core:0.11.16
-io.rsocket:rsocket-transport-netty:0.11.16
+io.rsocket.rpc:rsocket-rpc-core:0.2.14
+io.rsocket.rpc:rsocket-rpc-protobuf:0.2.14
+io.rsocket:rsocket-core:0.11.18
+io.rsocket:rsocket-transport-netty:0.11.18
 io.zipkin.brave:brave:5.6.1
 io.zipkin.reporter2:zipkin-reporter:2.7.14
 io.zipkin.zipkin2:zipkin:2.12.0

--- a/proteus-tracing-openzipkin/gradle/dependency-locks/protobufToolsLocator_rsocketRpc.lockfile
+++ b/proteus-tracing-openzipkin/gradle/dependency-locks/protobufToolsLocator_rsocketRpc.lockfile
@@ -1,4 +1,4 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-io.rsocket.rpc:rsocket-rpc-protobuf:0.2.13
+io.rsocket.rpc:rsocket-rpc-protobuf:0.2.14

--- a/proteus-tracing-openzipkin/gradle/dependency-locks/testCompile.lockfile
+++ b/proteus-tracing-openzipkin/gradle/dependency-locks/testCompile.lockfile
@@ -36,11 +36,11 @@ io.projectreactor.addons:reactor-adapter:3.2.2.RELEASE
 io.projectreactor.netty:reactor-netty:0.8.5.RELEASE
 io.projectreactor:reactor-core:3.2.6.RELEASE
 io.projectreactor:reactor-test:3.2.6.RELEASE
-io.rsocket.rpc:rsocket-rpc-core:0.2.13
-io.rsocket.rpc:rsocket-rpc-protobuf:0.2.13
-io.rsocket:rsocket-core:0.11.16
-io.rsocket:rsocket-transport-local:0.11.16
-io.rsocket:rsocket-transport-netty:0.11.16
+io.rsocket.rpc:rsocket-rpc-core:0.2.14
+io.rsocket.rpc:rsocket-rpc-protobuf:0.2.14
+io.rsocket:rsocket-core:0.11.18
+io.rsocket:rsocket-transport-local:0.11.18
+io.rsocket:rsocket-transport-netty:0.11.18
 io.zipkin.brave:brave:5.6.1
 io.zipkin.reporter2:zipkin-reporter:2.7.14
 io.zipkin.zipkin2:zipkin:2.12.0

--- a/proteus-tracing-openzipkin/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/proteus-tracing-openzipkin/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -36,11 +36,11 @@ io.projectreactor.addons:reactor-adapter:3.2.2.RELEASE
 io.projectreactor.netty:reactor-netty:0.8.5.RELEASE
 io.projectreactor:reactor-core:3.2.6.RELEASE
 io.projectreactor:reactor-test:3.2.6.RELEASE
-io.rsocket.rpc:rsocket-rpc-core:0.2.13
-io.rsocket.rpc:rsocket-rpc-protobuf:0.2.13
-io.rsocket:rsocket-core:0.11.16
-io.rsocket:rsocket-transport-local:0.11.16
-io.rsocket:rsocket-transport-netty:0.11.16
+io.rsocket.rpc:rsocket-rpc-core:0.2.14
+io.rsocket.rpc:rsocket-rpc-protobuf:0.2.14
+io.rsocket:rsocket-core:0.11.18
+io.rsocket:rsocket-transport-local:0.11.18
+io.rsocket:rsocket-transport-netty:0.11.18
 io.zipkin.brave:brave:5.6.1
 io.zipkin.reporter2:zipkin-reporter:2.7.14
 io.zipkin.zipkin2:zipkin:2.12.0

--- a/proteus-tracing-openzipkin/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/proteus-tracing-openzipkin/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -36,11 +36,11 @@ io.projectreactor.addons:reactor-adapter:3.2.2.RELEASE
 io.projectreactor.netty:reactor-netty:0.8.5.RELEASE
 io.projectreactor:reactor-core:3.2.6.RELEASE
 io.projectreactor:reactor-test:3.2.6.RELEASE
-io.rsocket.rpc:rsocket-rpc-core:0.2.13
-io.rsocket.rpc:rsocket-rpc-protobuf:0.2.13
-io.rsocket:rsocket-core:0.11.16
-io.rsocket:rsocket-transport-local:0.11.16
-io.rsocket:rsocket-transport-netty:0.11.16
+io.rsocket.rpc:rsocket-rpc-core:0.2.14
+io.rsocket.rpc:rsocket-rpc-protobuf:0.2.14
+io.rsocket:rsocket-core:0.11.18
+io.rsocket:rsocket-transport-local:0.11.18
+io.rsocket:rsocket-transport-netty:0.11.18
 io.zipkin.brave:brave:5.6.1
 io.zipkin.reporter2:zipkin-reporter:2.7.14
 io.zipkin.zipkin2:zipkin:2.12.0

--- a/proteus-vizceral-idl/gradle/dependency-locks/testCompile.lockfile
+++ b/proteus-vizceral-idl/gradle/dependency-locks/testCompile.lockfile
@@ -17,9 +17,9 @@ io.netty:netty-transport:4.1.33.Final
 io.projectreactor.netty:reactor-netty:0.8.5.RELEASE
 io.projectreactor:reactor-core:3.2.6.RELEASE
 io.projectreactor:reactor-test:3.2.6.RELEASE
-io.rsocket:rsocket-core:0.11.16
-io.rsocket:rsocket-transport-local:0.11.16
-io.rsocket:rsocket-transport-netty:0.11.16
+io.rsocket:rsocket-core:0.11.18
+io.rsocket:rsocket-transport-local:0.11.18
+io.rsocket:rsocket-transport-netty:0.11.18
 javax.inject:javax.inject:1
 junit:junit:4.12
 net.bytebuddy:byte-buddy-agent:1.9.7

--- a/proteus-vizceral-idl/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/proteus-vizceral-idl/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -17,9 +17,9 @@ io.netty:netty-transport:4.1.33.Final
 io.projectreactor.netty:reactor-netty:0.8.5.RELEASE
 io.projectreactor:reactor-core:3.2.6.RELEASE
 io.projectreactor:reactor-test:3.2.6.RELEASE
-io.rsocket:rsocket-core:0.11.16
-io.rsocket:rsocket-transport-local:0.11.16
-io.rsocket:rsocket-transport-netty:0.11.16
+io.rsocket:rsocket-core:0.11.18
+io.rsocket:rsocket-transport-local:0.11.18
+io.rsocket:rsocket-transport-netty:0.11.18
 javax.inject:javax.inject:1
 junit:junit:4.12
 net.bytebuddy:byte-buddy-agent:1.9.7


### PR DESCRIPTION
Only non-version change is to add RSocket overload of requestChannel for (Payload, Flux<Payload>) to NamedSErviceRsocket